### PR TITLE
Conflicts with dcos logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,13 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.25</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.25</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Temporary log scope 'provided' to avoid conflicts with dcos frameworks